### PR TITLE
Added download directly via datatorch

### DIFF
--- a/examples/download_export.py
+++ b/examples/download_export.py
@@ -1,9 +1,10 @@
 from datatorch.api import ApiClient
 from urllib.parse import urljoin
-import requests, json
+import requests, json, os
 
 base_url = "https://datatorch.io"
 apiUrl = urljoin(base_url, 'api/graphql')
+exportPath = "./"
 
 # Generate your API key here: datatorch.io/settings/access-tokens
 datatorchApiKey = 'API Key' ## replace
@@ -38,6 +39,20 @@ export_request = requests.get(export_link, headers = {"datatorch-api-key" : data
 
 if fileName.endswith((".json", ".JSON")):
   export = json.loads(export_request.content)
+    # Download the images and write to disk, assumes export format is COCO
+  for image in export["images"]:
+    # Collect the filename, and the datatorch ID to download via datatorch, and not directly the source Blob, S3 etc.
+    fileId = image["datatorch_id"]
+    fileName = image["file_name"]
+    
+    file_link = urljoin(base_url, "/api/file/v1/{0}/{1}?download=true&stream=true".format(fileId, fileName))
+
+    file_request = requests.get(file_link, headers = {"datatorch-api-key" : datatorchApiKey})
+
+    save_path = os.path.join(exportPath, fileName)
+    export_file = open(save_path, 'w+b')
+    export_file.write(file_request.content)
+    export_file.close()
 else:
   # For future export options that may not be JSON based.
   export = export_request.content


### PR DESCRIPTION
Extended the example to download the images that are in the export (assumed to be COCO for this example) via Datatorch and save them to disk. 