### PR TITLE
Added in the ability to supply the ApiClient

### DIFF
--- a/datatorch/api/scripts/import_coco.py
+++ b/datatorch/api/scripts/import_coco.py
@@ -134,6 +134,7 @@ def import_coco(
     max_iou: float = 0.99,
     simplify_tolerance: float = 0,
     ignore_annotations_with_ids: bool = True,
+    api: ApiClient = None,
 ):
     if not import_segmentation and not import_bbox:
         print("Nothing to import. Both segmentation and bbox are disabled.")
@@ -147,7 +148,9 @@ def import_coco(
 
     # Get DataTorch project information
     print("Connecting to DataTorch API.")
-    api = ApiClient()
+    if api is None:
+        api = ApiClient()
+        
     print("Loading Project Information.")
     if "/" in project_string:
         project: Project = api.project(*project_string.split("/", 1))


### PR DESCRIPTION
Added in the ability to supply the ApiClient that should already be connected to the appropriate endpoint with corresponding API key. Otherwise this attempts to connect to a default endpoint without authentication.

Does not change the behavior if no ApiClient is passed in (optional arg).